### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 To install the required dependencies for the SyncNode, run:
 
 ```bash
-yarn installl
+yarn install
 ```
 
 ### Usage


### PR DESCRIPTION
remove extraneous `l` in install