### PR TITLE
Handle no-websocket error gracefully

### DIFF
--- a/src/services/WebSocketService.ts
+++ b/src/services/WebSocketService.ts
@@ -71,11 +71,13 @@ class _WebSocketService {
   private _connect(): void {
     if (this._isConnected) return;
 
-    this._ws = new WebSocket(`${this._url}api_key=${this._config?.apiKey}`);
+    this._ws = this._url ? 
+      new WebSocket(`${this._url}api_key=${this._config?.apiKey}`)
+      : null;
 
-    this._ws.on('close', this._onClose.bind(this));
-    this._ws.on('error', this._onError.bind(this));
-    this._ws.on('message', this._onMessage.bind(this));
+    this._ws?.on('close', this._onClose.bind(this));
+    this._ws?.on('error', this._onError.bind(this));
+    this._ws?.on('message', this._onMessage.bind(this));
   }
   /**
    * # _onOpen


### PR DESCRIPTION
The light node says it supports polygon but crashes when you try to do it. 
Cause is that there is no reservoir websocket URL for polygon (ie see `src/types/index.ts:33` which only has goerli and mainnet). 

This PR unbreaks polygon by not attempting to connect the websocket if an unsupported chain is used.