### PR TITLE
Fix bug in websocket

### DIFF
--- a/src/services/WebSocketService.ts
+++ b/src/services/WebSocketService.ts
@@ -120,7 +120,7 @@ class _WebSocketService {
       this._subscribe('bid.updated');
     }
 
-    if (this._config.toSync.bids) {
+    if (this._config.toSync.sales) {
       this._subscribe('sale.created');
       this._subscribe('sale.updated');
     }


### PR DESCRIPTION
Looks like sales only get synced in the websocket if `bids` are set to sync. I am not positive but it seems that sales should be track if `sales` are set to sync.